### PR TITLE
fix(ci): publish PR previews without touching deploy tags

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -82,47 +82,43 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: true
+          # Pull requests are a build check only: they prove the Dockerfile still
+          # builds end to end, but publishing them would litter GHCR with pr-N
+          # package versions that nothing ever deploys.
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
           # the build reaches the database over Tailscale during static generation
           network: host
           # Passed as BuildKit secrets: mounted only for the RUN that needs them
-          # and never persisted into an image layer or the build cache.
-          # next.config.ts validates the whole env schema before building, so
-          # every required value must be present — but only DATABASE_URL is
-          # actually used (generateStaticParams() queries Payload in six routes).
+          # and never persisted into an image layer or the build cache. This list
+          # mirrors the --mount=type=secret block in the Dockerfile, which in
+          # turn mirrors buildTimeEnvKeys in src/types/environment.ts. Runtime-only
+          # secrets are deliberately absent — the build never reads them, and
+          # Dokploy supplies them from Doppler at boot.
+          #
+          # S3_BUCKET/REGION/ENDPOINT are not secret, but they travel here rather
+          # than as build-args because the prerender pass reads them through the
+          # same secret mount as the rest; a build-arg would not be visible to it.
           secrets: |
             DATABASE_URL=${{ secrets.DATABASE_URL }}
-            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             PAYLOAD_SECRET=${{ secrets.PAYLOAD_SECRET }}
-            PREVIEW_SECRET=${{ secrets.PREVIEW_SECRET }}
-            CRON_SECRET=${{ secrets.CRON_SECRET }}
             REDIS_URL=${{ secrets.REDIS_URL }}
-            S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }}
-            S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }}
-            UMAMI_USERNAME=${{ secrets.UMAMI_USERNAME }}
-            UMAMI_PASSWORD=${{ secrets.UMAMI_PASSWORD }}
-            USESEND_API_KEY=${{ secrets.USESEND_API_KEY }}
-            OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}
-            ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}
-            MAPBOX_API_KEY=${{ secrets.MAPBOX_API_KEY }}
-          # Non-secret config. SERVER_URL / STATUS_PAGE_URL / SENTRY_DSN are
-          # inlined into the client bundle by next.config.ts's `env:` block; the
-          # rest only need to be present for schema validation and are supplied
-          # again at runtime by Dokploy.
-          build-args: |
-            SERVER_URL=${{ vars.SERVER_URL }}
-            SERVER_HOST=${{ vars.SERVER_HOST }}
-            STATUS_PAGE_URL=${{ vars.STATUS_PAGE_URL }}
-            STATUS_PAGE_HEARTBEAT_URL=${{ vars.STATUS_PAGE_HEARTBEAT_URL }}
-            SENTRY_DSN=${{ vars.SENTRY_DSN }}
             S3_BUCKET=${{ vars.S3_BUCKET }}
             S3_REGION=${{ vars.S3_REGION }}
             S3_ENDPOINT=${{ vars.S3_ENDPOINT }}
-            NEXT_PUBLIC_UMAMI_URL=${{ vars.NEXT_PUBLIC_UMAMI_URL }}
-            NEXT_PUBLIC_UMAMI_SITE_ID=${{ vars.NEXT_PUBLIC_UMAMI_SITE_ID }}
-            USESEND_URL=${{ vars.USESEND_URL }}
-            USESEND_DEFAULT_FROM_ADDRESS=${{ vars.USESEND_DEFAULT_FROM_ADDRESS }}
-            USESEND_DEFAULT_FROM_NAME=${{ vars.USESEND_DEFAULT_FROM_NAME }}
+            S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }}
+            S3_SECRET_KEY=${{ secrets.S3_SECRET_KEY }}
+            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+            SENTRY_ORG=${{ vars.SENTRY_ORG }}
+            SENTRY_PROJECT=${{ vars.SENTRY_PROJECT }}
+          # The only three values baked into the image, all public: Next inlines
+          # them via next.config.ts's `env:` block and they are captured in the
+          # prerendered shell, so they cannot be supplied at runtime. Everything
+          # else is read from the container environment at boot.
+          build-args: |
+            SERVER_URL=${{ vars.SERVER_URL }}
+            STATUS_PAGE_URL=${{ vars.STATUS_PAGE_URL }}
+            SENTRY_DSN=${{ vars.SENTRY_DSN }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -67,14 +67,31 @@ jobs:
       - name: Compute image metadata
         id: meta
         uses: docker/metadata-action@v6
+        env:
+          # Makes `type=ref,event=pr` use the head branch name instead of the PR
+          # number, so the preview tag reads as the feature branch. The action
+          # slugifies it: slashes become dashes and the result is lowercased.
+          DOCKER_METADATA_PR_HEAD_REF: 'true'
         with:
           images: ghcr.io/${{ github.repository }}/web
+          # A pull request publishes a preview image so the implementation can be
+          # pulled and checked visually. It is tagged from the *head* branch —
+          # preview-chore-doppler-config-management — which is stable for the life
+          # of the PR and says what it is at a glance.
+          #
+          # `type=ref,event=branch` is gated to non-PR events on purpose. On a
+          # pull_request it resolves to the BASE branch, so a PR against develop
+          # would tag its image `develop` and overwrite the tag Dokploy deploys
+          # from. Nothing would deploy at that moment — the deploy job is gated to
+          # pushes — but the next restart or redeploy would pull the PR's image.
+          # Gating it keeps develop/production/latest writable only by a
+          # post-merge push. The type=raw lines below are already safe: they test
+          # github.ref, which on a PR is refs/pull/N/merge and never matches.
           tags: |
             type=sha,prefix=sha-,format=short
-            type=ref,event=branch
-            type=ref,event=pr
+            type=ref,event=branch,enable=${{ github.event_name != 'pull_request' }}
+            type=ref,event=pr,prefix=preview-
             type=raw,value=production,enable=${{ github.ref == 'refs/heads/main' }}
-            type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push web image
@@ -82,10 +99,10 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          # Pull requests are a build check only: they prove the Dockerfile still
-          # builds end to end, but publishing them would litter GHCR with pr-N
-          # package versions that nothing ever deploys.
-          push: ${{ github.event_name != 'pull_request' }}
+          # Every run publishes, including pull requests — a PR's preview image is
+          # there to be pulled and inspected. What a PR must not do is write the
+          # tags a deployment follows; see the tag list above.
+          push: true
           platforms: linux/amd64,linux/arm64
           # the build reaches the database over Tailscale during static generation
           network: host

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,50 +31,35 @@ COPY --from=deps /repo/node_modules ./node_modules
 COPY --from=deps /repo/apps/web/node_modules ./apps/web/node_modules
 COPY . .
 ENV NODE_ENV=production
-# Only genuinely build-time values are declared here, and none of them are secret.
+# Exactly three values are baked into the image, and all three are public.
 #
 # Next inlines everything listed in next.config.ts's `env:` block into the compiled
-# bundle, so those values are frozen at build time and cannot be changed by the
-# runtime environment. Two of them are read from client components
-# ('use client': packages/ui/src/ServiceStatus and src/components/LivePreviewListener),
-# which means they MUST be correct here — a placeholder would ship to the browser.
+# bundle, where the runtime environment can no longer change it. On top of that,
+# `cacheComponents: true` gives nearly every route a shell rendered at build time,
+# so a server-side process.env read is captured into that shell and served from
+# cache. Between the two, these three cannot be made runtime-configurable:
 #
-# Everything else — secrets and server-only config alike — is deliberately absent:
-# it is read from the container environment at boot, so Doppler/Dokploy supply it
-# at runtime and it never lands in an image layer.
+#   SERVER_URL       robots.ts and the root layout's metadataBase, both prerendered
+#   STATUS_PAGE_URL  reaches ServiceStatus through the prerendered Footer
+#   SENTRY_DSN       Sentry.init runs at module scope in instrumentation-client.ts
 #
-# The remaining ARGs below are not inlined; they exist only because next.config.ts
-# validates the full schema before building. A Sentry DSN is public by design — it
-# ships to the browser SDK — so it is a build arg rather than a secret.
+# The consequence is that an image is specific to one environment. Nothing secret
+# is involved: a DSN ships to the browser SDK either way, and the other two are
+# this site's own public addresses.
+#
+# Every secret and all server-only config is deliberately absent — it is read from
+# the container environment at boot, so it never lands in a layer.
 ARG SERVER_URL
-ARG SERVER_HOST
 ARG STATUS_PAGE_URL
-ARG STATUS_PAGE_HEARTBEAT_URL
 ARG SENTRY_DSN
-ARG S3_BUCKET
-ARG S3_REGION
-ARG S3_ENDPOINT
-ARG NEXT_PUBLIC_UMAMI_URL
-ARG NEXT_PUBLIC_UMAMI_SITE_ID
-ARG USESEND_URL
-ARG USESEND_DEFAULT_FROM_ADDRESS
-ARG USESEND_DEFAULT_FROM_NAME
 ENV SERVER_URL=$SERVER_URL \
-    SERVER_HOST=$SERVER_HOST \
     STATUS_PAGE_URL=$STATUS_PAGE_URL \
-    STATUS_PAGE_HEARTBEAT_URL=$STATUS_PAGE_HEARTBEAT_URL \
-    SENTRY_DSN=$SENTRY_DSN \
-    S3_BUCKET=$S3_BUCKET \
-    S3_REGION=$S3_REGION \
-    S3_ENDPOINT=$S3_ENDPOINT \
-    NEXT_PUBLIC_UMAMI_URL=$NEXT_PUBLIC_UMAMI_URL \
-    NEXT_PUBLIC_UMAMI_SITE_ID=$NEXT_PUBLIC_UMAMI_SITE_ID \
-    USESEND_URL=$USESEND_URL \
-    USESEND_DEFAULT_FROM_ADDRESS=$USESEND_DEFAULT_FROM_ADDRESS \
-    USESEND_DEFAULT_FROM_NAME=$USESEND_DEFAULT_FROM_NAME
-# Fail loudly at build time rather than silently baking `undefined` into the client
-# bundle, which would surface much later as a broken status link / live preview.
+    SENTRY_DSN=$SENTRY_DSN
+# Fail loudly rather than baking `undefined` into the client bundle and the
+# prerendered robots.txt, which surfaces much later as a broken status link,
+# wrong canonical URLs, and `Sitemap: undefined/sitemap.xml`.
 RUN test -n "$SERVER_URL" || { echo "SERVER_URL build arg is required (inlined into the client bundle)" >&2; exit 1; }
+RUN test -n "$STATUS_PAGE_URL" || { echo "STATUS_PAGE_URL build arg is required (inlined into the client bundle)" >&2; exit 1; }
 # pnpm's "deps status" check tries to interactively confirm removal of a stale
 # node_modules dir when it detects the manifest changed since install; there is no TTY
 # in a Docker build, so this aborts unless CI=true tells pnpm to run non-interactively.
@@ -83,24 +68,26 @@ ENV CI=true
 # reachable database. It arrives as a BuildKit secret — mounted only for the lifetime
 # of this RUN, never written to a layer or recorded in build-cache metadata.
 # SENTRY_AUTH_TOKEN is optional and only enables source-map upload when present.
+# Only what the build itself reads, matching buildTimeEnvKeys in
+# src/types/environment.ts: the database and Payload's secret for the prerender
+# pass, the S3 settings the media collections resolve against, and the optional
+# Sentry credentials for source-map upload. Runtime-only secrets are no longer
+# passed at all — the build has no use for them, and not passing them is one
+# fewer place they can leak.
 RUN --mount=type=secret,id=DATABASE_URL \
-    --mount=type=secret,id=SENTRY_AUTH_TOKEN \
     --mount=type=secret,id=PAYLOAD_SECRET \
-    --mount=type=secret,id=PREVIEW_SECRET \
-    --mount=type=secret,id=CRON_SECRET \
     --mount=type=secret,id=REDIS_URL \
+    --mount=type=secret,id=S3_BUCKET \
+    --mount=type=secret,id=S3_REGION \
+    --mount=type=secret,id=S3_ENDPOINT \
     --mount=type=secret,id=S3_ACCESS_KEY \
     --mount=type=secret,id=S3_SECRET_KEY \
-    --mount=type=secret,id=UMAMI_USERNAME \
-    --mount=type=secret,id=UMAMI_PASSWORD \
-    --mount=type=secret,id=USESEND_API_KEY \
-    --mount=type=secret,id=OPENAI_API_KEY \
-    --mount=type=secret,id=ANTHROPIC_API_KEY \
-    --mount=type=secret,id=MAPBOX_API_KEY \
-    for s in DATABASE_URL SENTRY_AUTH_TOKEN PAYLOAD_SECRET PREVIEW_SECRET \
-             CRON_SECRET REDIS_URL S3_ACCESS_KEY S3_SECRET_KEY \
-             UMAMI_USERNAME UMAMI_PASSWORD USESEND_API_KEY \
-             OPENAI_API_KEY ANTHROPIC_API_KEY MAPBOX_API_KEY; do \
+    --mount=type=secret,id=SENTRY_AUTH_TOKEN \
+    --mount=type=secret,id=SENTRY_ORG \
+    --mount=type=secret,id=SENTRY_PROJECT \
+    for s in DATABASE_URL PAYLOAD_SECRET REDIS_URL S3_BUCKET S3_REGION S3_ENDPOINT \
+             S3_ACCESS_KEY S3_SECRET_KEY \
+             SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT; do \
       # Quoting the whole assignment word keeps values containing spaces or shell
       # metacharacters intact, which bare `export $(...)` word-splitting would mangle.
       # Do NOT use `read` here: it returns 1 at EOF when the file has no trailing

--- a/README.md
+++ b/README.md
@@ -129,10 +129,87 @@ sampling.
 `CLOUDFLARE_TUNNEL_HOST`, `CLOUDFLARE_TUNNEL_URL` and `CLOUDFLARE_TUNNEL_TOKEN` are only
 read when starting the dev server with `--tunnel`.
 
-> **Inlined at build time.** `SERVER_URL`, `STATUS_PAGE_URL` and `SENTRY_DSN` are listed in
-> `next.config.ts`'s `env:` block, which bakes them into the compiled bundle. They must be
-> correct when the image is built and cannot be changed by the runtime environment.
-> Everything else is read from the container environment at boot.
+> **Fixed at build time.** `SERVER_URL`, `STATUS_PAGE_URL` and `SENTRY_DSN` are listed in
+> `next.config.ts`'s `env:` block, which inlines them into the compiled bundle. On top of
+> that, `cacheComponents: true` gives nearly every route a shell rendered at build time,
+> so a server-side `process.env` read is captured into that shell and served from cache —
+> moving the read further up the tree does not change this. All three must therefore be
+> correct when the image is built, which makes an image specific to one environment. All
+> three are public values, so nothing secret is baked in.
+>
+> Everything else — every secret and all server-only config — is read from the container
+> environment at boot. See `buildTimeEnvKeys` in `src/types/environment.ts` for the exact
+> set the build requires.
+
+## Running the Container Locally
+
+The image contains no `.env` and no Doppler CLI: in production Dokploy injects the
+environment, and in CI the Doppler GitHub App syncs into GitHub environments. Neither
+exists on your machine, so both the build and the run have to be wrapped in `doppler run`
+yourself.
+
+### Build
+
+Three public URLs are baked in as build args (see the callout above), so an image belongs
+to one environment. Everything else the build needs arrives as a BuildKit secret, mounted
+only for the build `RUN` so it never lands in a layer or in build-cache metadata. The
+exact set is `buildTimeEnvKeys` in `src/types/environment.ts`.
+
+The build needs a reachable database because `generateStaticParams()` calls
+`payload.find()`, and a Redis URL because the KV adapter is constructed while
+`payload.config.ts` loads.
+
+```bash
+doppler run -- sh -c 'docker build \
+  --build-arg SERVER_URL="$SERVER_URL" \
+  --build-arg STATUS_PAGE_URL="$STATUS_PAGE_URL" \
+  --build-arg SENTRY_DSN="$SENTRY_DSN" \
+  --secret id=DATABASE_URL,env=DATABASE_URL \
+  --secret id=PAYLOAD_SECRET,env=PAYLOAD_SECRET \
+  --secret id=REDIS_URL,env=REDIS_URL \
+  --secret id=S3_BUCKET,env=S3_BUCKET \
+  --secret id=S3_REGION,env=S3_REGION \
+  --secret id=S3_ENDPOINT,env=S3_ENDPOINT \
+  --secret id=S3_ACCESS_KEY,env=S3_ACCESS_KEY \
+  --secret id=S3_SECRET_KEY,env=S3_SECRET_KEY \
+  --secret id=SENTRY_AUTH_TOKEN,env=SENTRY_AUTH_TOKEN \
+  --secret id=SENTRY_ORG,env=SENTRY_ORG \
+  --secret id=SENTRY_PROJECT,env=SENTRY_PROJECT \
+  -t website:local .'
+```
+
+The Sentry trio is optional and only enables source-map upload. A production build
+validates only the build-time subset of the schema; the full schema is validated at boot,
+so a missing runtime variable still fails fast — at the point where it can be supplied.
+
+### Run
+
+At boot the app reads everything from the container environment, so the whole Doppler
+config can be handed over as an env file:
+
+```bash
+docker run --rm -p 3000:3000 \
+  --env-file <(doppler secrets download --no-file --format docker) \
+  website:local
+```
+
+`--format docker` emits plain `KEY=value` lines, which is what `--env-file` expects.
+Docker does no shell interpretation on that file — no quoting, no `$` expansion — so
+values containing spaces or metacharacters pass through literally.
+
+Notes:
+
+- **The image is environment-specific.** `SERVER_URL`, `STATUS_PAGE_URL` and `SENTRY_DSN`
+  are fixed when the image is built, so passing them at run time only satisfies the
+  schema check — it does not change what is served. Build with the config you intend to
+  run. Every secret and all server-only config *is* runtime, so a container can be
+  repointed at a different database, cache, bucket or mail provider without rebuilding.
+- **Private hosts need Tailscale.** The `development` config points `DATABASE_URL` and
+  `REDIS_URL` at hosts on the tailnet. They resolve and connect from a container on a
+  machine that is already on the tailnet; elsewhere, set `TAILSCALE_AUTHKEY` and the
+  entrypoint brings up userspace-networking `tailscaled` before starting Next.
+- **`docker compose up -d` is only the local infrastructure** (Mongo, Redis, rustfs).
+  The app is not a compose service — it runs via `pnpm dev`, or as the container above.
 
 ## Available Scripts
 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,13 +3,13 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { NextConfig } from 'next'
-import { PHASE_DEVELOPMENT_SERVER } from 'next/constants'
+import { PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_BUILD } from 'next/constants'
 import { withPayload } from '@payloadcms/next/withPayload'
 
 import { withSentryConfig } from '@sentry/nextjs'
 import z from 'zod'
 
-import { envSchema } from '@/types/environment'
+import { buildTimeEnvSchema, envSchema } from '@/types/environment'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -64,7 +64,19 @@ const createTunnel = (token: string) =>
   })
 
 export default async (phase, { defaultConfig }) => {
-  const parsedEnv = envSchema.safeParse(process.env)
+  /**
+   *    Environment validation
+   *
+   *    A production build validates only the build-time subset: requiring the
+   *    full schema here would force every value to be supplied as a build arg
+   *    and baked into the image, making the image environment-specific. The
+   *    server validates the full schema at boot instead (`next start` runs
+   *    this config file too, under a different phase), so a missing runtime
+   *    variable still fails fast — just at the point where it can actually be
+   *    supplied.
+   */
+  const schema = phase === PHASE_PRODUCTION_BUILD ? buildTimeEnvSchema : envSchema
+  const parsedEnv = schema.safeParse(process.env)
   if (!parsedEnv.success) {
     console.error(`\n${z.prettifyError(parsedEnv.error)}\n`)
     process.exit(1)
@@ -154,16 +166,28 @@ export default async (phase, { defaultConfig }) => {
      *    Environment Variables
      *
      *    Anything listed here is INLINED into the compiled bundle by Next and
-     *    can no longer be changed by the runtime environment. So this list is
-     *    deliberately limited to values that client components read:
+     *    can no longer be changed by the runtime environment.
      *
-     *      - SERVER_URL      → src/components/LivePreviewListener ('use client')
-     *      - STATUS_PAGE_URL → @repo/ui ServiceStatus ('use client')
-     *      - SENTRY_DSN      → public by design, shipped to the browser SDK
+     *    These three are structurally build-time and cannot be made runtime,
+     *    which is worth stating plainly because it is not obvious:
      *
-     *    SERVER_HOST and STATUS_PAGE_HEARTBEAT_URL were removed: both are read
-     *    only on the server, so leaving them here would freeze deployment
-     *    config into the image for no reason.
+     *      - SENTRY_DSN      → instrumentation-client.ts calls Sentry.init at
+     *                          module scope, before any component renders.
+     *      - SERVER_URL      → read by robots.ts and the root layout's
+     *                          metadataBase, both of which are prerendered.
+     *      - STATUS_PAGE_URL → reaches ServiceStatus through the Footer, which
+     *                          renders inside the prerendered shell.
+     *
+     *    With `cacheComponents: true` nearly every route has a shell rendered
+     *    at build time, so a process.env read on the server is captured into
+     *    that shell and served from cache — moving the read up the tree does
+     *    not change this. All three are public values (a DSN ships to the
+     *    browser SDK; the other two are this site's own addresses), so the
+     *    cost is that images are environment-specific, not that anything
+     *    secret is baked in.
+     *
+     *    Everything else — every secret and all server-only config — is read
+     *    from the container environment at boot and is genuinely runtime.
      */
     env: {
       SERVER_URL: process.env.SERVER_URL,
@@ -252,7 +276,11 @@ export default async (phase, { defaultConfig }) => {
         384,
       ],
       remotePatterns: [
-        new URL(`${process.env.SERVER_URL}/**`),
+        // Deliberately a static list rather than `new URL(SERVER_URL)`: Next
+        // needs these at build time to compile the image optimizer, and
+        // reading SERVER_URL here would put a build-time env dependency back
+        // into an otherwise environment-portable image. Every host the app is
+        // served from is enumerated below.
         new URL('https://daniel.heene.io/**'),
         new URL('https://daniel.heene.dev/**'),
         new URL('https://daniel.heene.review/**'),

--- a/apps/web/src/types/environment.ts
+++ b/apps/web/src/types/environment.ts
@@ -11,6 +11,38 @@ import { z } from 'zod'
 const emptyAsUndefined = <T extends z.ZodType>(schema: T) =>
   z.preprocess((value) => (value === '' ? undefined : value), schema.optional())
 
+/**
+ * Variables the *build* genuinely needs.
+ *
+ * `next build` prerenders routes whose generateStaticParams() calls
+ * payload.find(), so the database, Payload's secret and the media/S3 settings
+ * have to be present. Everything outside this set is only ever read once the
+ * server is running, and requiring it at build time would force each value to
+ * be baked into the image — which is exactly what makes an image
+ * environment-specific.
+ *
+ * Kept as a key list rather than a second schema so there is one source of
+ * truth for each variable's shape.
+ */
+export const buildTimeEnvKeys = [
+  // Inlined into the bundle and/or captured in a prerendered shell — see the
+  // `env:` block in next.config.ts. Required here so a build without them
+  // fails immediately instead of shipping `undefined` to the browser.
+  'SERVER_URL',
+  'STATUS_PAGE_URL',
+  'DATABASE_URL',
+  'PAYLOAD_SECRET',
+  // The Redis KV adapter is constructed while payload.config.ts loads, so the
+  // prerender pass fails without it ("redisURL or REDIS_URL env variable is
+  // required") even though nothing reads from the cache during the build.
+  'REDIS_URL',
+  'S3_BUCKET',
+  'S3_REGION',
+  'S3_ENDPOINT',
+  'S3_ACCESS_KEY',
+  'S3_SECRET_KEY',
+] as const
+
 export const envSchema = z.object({
   NODE_ENV: z
     .enum([
@@ -74,3 +106,21 @@ export const envSchema = z.object({
 })
 
 export type Env = z.infer<typeof envSchema>
+
+/**
+ * The build-time subset of {@link envSchema}.
+ *
+ * `next build` validates with this; the running server validates with the full
+ * schema at boot. Both derive from the same field definitions, so a variable
+ * can never be validated one way during the build and another at runtime.
+ */
+export const buildTimeEnvSchema = envSchema.pick(
+  Object.fromEntries(
+    buildTimeEnvKeys.map((key) => [
+      key,
+      true,
+    ]),
+  ) as {
+    [K in (typeof buildTimeEnvKeys)[number]]: true
+  },
+)


### PR DESCRIPTION
Follow-up to #35, which landed the Doppler environment work. This carries the fixes that were still outstanding on the branch.

## Pull requests publish a preview image

A PR builds a real image worth pulling — checking an implementation visually is the point — so it publishes under a tag derived from the **head** branch: `preview-chore-doppler-config-management`. Stable for the life of the PR and legible at a glance.

What a PR must not do is write a tag a deployment follows. `type=ref,event=branch` resolves to the **base** branch on a `pull_request`, so a PR against develop was tagging its image `develop` — the tag Dokploy pulls. Nothing deployed at that moment, since the `deploy` job is gated to pushes, but the next restart or redeploy would have served the PR's image.

That rule is now gated to non-PR events, so `develop` / `main` / `production` / `latest` are writable only by a post-merge push:

| Event | Tags written |
|---|---|
| PR → develop | `preview-<head-branch-slug>`, `sha-<short>` |
| PR → main | `preview-<head-branch-slug>`, `sha-<short>` |
| push develop | `develop`, `sha-<short>` |
| push main | `main`, `production`, `latest`, `sha-<short>` |

`DOCKER_METADATA_PR_HEAD_REF` is what makes the preview tag use the branch name rather than the PR number. The redundant `type=raw,value=develop` rule is dropped — `type=ref,event=branch` already emits that tag on a push to develop.

## Build inputs reconciled with what the build reads

Narrowing the build-time env surface left the workflow and the Dockerfile disagreeing: `S3_BUCKET` / `S3_REGION` / `S3_ENDPOINT` were passed as build-args while the Dockerfile had moved them to secret mounts. A build-arg is not visible to `--mount=type=secret`, so the prerender pass would have failed schema validation.

- Those three move to `secrets:`, alongside `SENTRY_ORG` / `SENTRY_PROJECT`, which the Dockerfile mounts but the workflow never passed.
- The 8 secrets and 10 build-args nothing consumes are dropped.
- `buildTimeEnvKeys` in `src/types/environment.ts` is now the single source of truth; the Dockerfile's mount list and the workflow's inputs both mirror it.

## Platforms

Dropped `macps`, which is not a valid platform string and would have failed the build outright, along with `linux/arm/v7`. Leaves `linux/amd64,linux/arm64`.

## Verification

- Tag resolution simulated across all four event types — no PR path writes a protected tag.
- Dockerfile mounts, workflow inputs, and `buildTimeEnvKeys` cross-checked in both directions; every required key is reachable by the build.
- `tsc --noEmit` shows 3 errors in `src/lib/jsonLd/jsonLd.test.ts`; these are pre-existing on `develop` (identical count on both branches) and untouched here.
- This PR is the first run of the fixed pipeline — nothing triggers on the branch itself.

## Not included

Pruning the existing `pr-*` package versions from GHCR. This stops new ones under that naming; the accumulated versions still need a cleanup pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)