### PR TITLE
fix: clear the blocking biome lint errors

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -26,7 +26,8 @@
       "!!**/node_modules",
       "!!**/coverage",
       "!!**/playwright-report",
-      "!!**/test-results"
+      "!!**/test-results",
+      "!!**/next-env.d.ts"
     ],
     "ignoreUnknown": false
   }

--- a/src/components/Toasty/Toasty.tsx
+++ b/src/components/Toasty/Toasty.tsx
@@ -471,7 +471,6 @@ export const Toasty = function Toasty(): React.JSX.Element {
   const { track } = useUmami()
   const audioContextRef = React.useRef<AudioContext>(null)
   const keyEventBoundRef = React.useRef<boolean>(false)
-  const [eventIsRegistered, setEventIsRegistered] = React.useState(false)
   const [{ success, imageBlob, audioBuffer }, dispatch] = React.useReducer(reducer, initialState)
 
   const handleKeyUpEvent = React.useCallback((event: KeyboardEvent): void => {
@@ -482,7 +481,9 @@ export const Toasty = function Toasty(): React.JSX.Element {
   }, [])
 
   /**
-   *
+   *    Binds the konami-code listener once for the component's lifetime.
+   *    handleKeyUpEvent is a useCallback with no dependencies, so it is stable
+   *    and the effect never re-runs.
    */
   React.useEffect(() => {
     if (!keyEventBoundRef.current) {
@@ -498,7 +499,7 @@ export const Toasty = function Toasty(): React.JSX.Element {
       }
     }
   }, [
-    eventIsRegistered,
+    handleKeyUpEvent,
   ])
 
   /**

--- a/src/components/hooks/use-server-sent-events.ts
+++ b/src/components/hooks/use-server-sent-events.ts
@@ -67,7 +67,19 @@ export const useServerSentEvents = <T = unknown>({
       return
     }
 
-    const source = new EventSource(`/api/sse?channel=${encodeURIComponent(channel)}`)
+    // reconnectToken is what re-runs this effect: reconnect() bumps it, which
+    // tears the EventSource down and opens a fresh one. Carrying it in the URL
+    // both makes that dependency real rather than incidental, and stops a
+    // forced reconnect from being served a cached response.
+    //
+    // Built by hand rather than with URLSearchParams: that encodes a space as
+    // `+` (form encoding) where encodeURIComponent emits `%20`. Both decode the
+    // same server-side, but the channel name is asserted verbatim in tests and
+    // there is no reason to change the wire format here.
+    const source = new EventSource(
+      `/api/sse?channel=${encodeURIComponent(channel)}` +
+        (reconnectToken > 0 ? `&r=${reconnectToken}` : ''),
+    )
     setStatus('connecting')
 
     let lastActivity = Date.now()

--- a/src/lib/references/extractReferences.ts
+++ b/src/lib/references/extractReferences.ts
@@ -140,7 +140,9 @@ export const extractReferences = (
     if (!node || typeof node !== 'object') return
 
     if (Array.isArray(node)) {
-      node.forEach((item, index) => walk(item, joinPath(path, index), fieldName))
+      node.forEach((item, index) => {
+        walk(item, joinPath(path, index), fieldName)
+      })
       return
     }
 

--- a/src/stories/components/IconGallery.tsx
+++ b/src/stories/components/IconGallery.tsx
@@ -12,7 +12,11 @@ interface IconItemProps {
 /** An individual icon with a caption and an example (passed as `children`). */
 export const IconItem: FunctionComponent<IconItemProps> = ({ name, children }) => (
   <div className="inline-flex flex-col items-center flex-[0_1_calc(20%-50px)] min-w-30 m-3.75">
-    <div
+    {/* a button rather than a div with onClick: the tile is click-to-copy, so it
+        needs to be keyboard-reachable and announced as an action */}
+    <button
+      type="button"
+      aria-label={`Copy icon name "${name}" to clipboard`}
       className={cn(
         'rounded-md border border-border bg-card shadow-[0_1px_3px_rgba(0,0,0,0.10)] dark:shadow-[0_2px_5px_rgba(0,0,0,0.20)]',
         'overflow-hidden text-[3rem] h-[2em] w-[2em] flex items-center justify-center flex-none [&>img]:w-[1em] [&>img]:h-[1em] [&>svg]:w-[1em] [&>svg]:h-[1em]',
@@ -22,7 +26,7 @@ export const IconItem: FunctionComponent<IconItemProps> = ({ name, children }) =
       }}
     >
       {children}
-    </div>
+    </button>
     <div className="font-mono text-sm font-bold text-foreground mt-[1em] leading-[1.2] text-center">
       {name}
     </div>


### PR DESCRIPTION
Stacked on #37 — merge that first.

Flattening the monorepo brought every file under one biome run (Turbo had scoped it per package), which surfaced errors that were already in the tree. Seven of them blocked every commit, which is why #37 had to use `--no-verify` throughout. This clears them, and the pre-commit hook passes normally again.

## What was actually blocking

Only 7 errors, and they were correctness issues rather than style noise:

| File | Problem | Fix |
|---|---|---|
| `Toasty.tsx` | Effect depended on `eventIsRegistered` — a `useState` whose setter is never called, so permanently `false` and unable to re-run anything | Dropped the dead state; listed the real dependency (`handleKeyUpEvent`, a stable `useCallback`) |
| `use-server-sent-events.ts` | `reconnectToken` flagged as an unnecessary dependency | See below — the suggested fix was wrong |
| `extractReferences.ts` | Concise arrow returned `walk()`'s value into `forEach`, which discards it | Block body |
| `IconGallery.tsx` | Click-to-copy tile was a `div` with `onClick` — keyboard-unreachable and unannounced | Real `<button>` with an `aria-label` |
| `next-env.d.ts` | Next rewrites it on every build; formatting it is churn that comes straight back | Excluded from biome |

## The SSE hook needs a second look in review

Biome's suggested fix was to remove `reconnectToken` from the dependency list, because nothing inside the effect reads it. **Applying that would have silently broken reconnection.** The token exists solely to re-run the effect — `reconnect()` bumps it, which tears the `EventSource` down and opens a fresh one. Removing it leaves the stale-connection check firing forever with no effect.

It now rides along in the request URL, which makes the dependency real rather than incidental and stops a forced reconnect from being served a cached response. The SSE route reads only `channel` and validates it against an allowlist, so the extra `r` param is ignored.

The query string is still assembled by hand rather than with `URLSearchParams`: that encodes a space as `+` where `encodeURIComponent` emits `%20`. Both decode identically server-side, but it broke an existing assertion in `use-server-sent-events.test.ts`, and changing the wire format to satisfy a linter is the wrong trade.

## Left alone

84 warnings and 41 infos — `noExplicitAny` (23), `useLiteralKeys` (38), unused variables and imports (49). None block commits. Mechanical but wide-reaching, so they belong in their own pass.

## Verified

- `biome check` — **0 errors** across 525 files
- 221 unit tests pass
- `next build` — 72 static pages
- Committed **without** `--no-verify`; the pre-commit hook passes on its own

🤖 Generated with [Claude Code](https://claude.com/claude-code)